### PR TITLE
Add missing types to react-native-image-pan-zoom

### DIFF
--- a/built/image-zoom/image-zoom.component.d.ts
+++ b/built/image-zoom/image-zoom.component.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { LayoutChangeEvent } from 'react-native';
 import { ICenterOn, ImageZoomProps, ImageZoomState } from './image-zoom.type';
-export default class ImageViewer extends React.Component<ImageZoomProps, ImageZoomState> {
+export default class ImageViewer extends React.Component<React.PropsWithChildren<ImageZoomProps>, ImageZoomState> {
     static defaultProps: ImageZoomProps;
     state: ImageZoomState;
     private lastPositionX;

--- a/src/image-zoom/image-zoom.component.tsx
+++ b/src/image-zoom/image-zoom.component.tsx
@@ -3,7 +3,7 @@ import { Animated, LayoutChangeEvent, PanResponder, StyleSheet, View } from 'rea
 import styles from './image-zoom.style';
 import { ICenterOn, ImageZoomProps, ImageZoomState } from './image-zoom.type';
 
-export default class ImageViewer extends React.Component<ImageZoomProps, ImageZoomState> {
+export default class ImageViewer extends React.Component<React.PropsWithChildren<ImageZoomProps>, ImageZoomState> {
   public static defaultProps = new ImageZoomProps();
   public state = new ImageZoomState();
 


### PR DESCRIPTION
This PR adds React.PropsWithChildren to fix TypeScript errors in CoreP app with RN 0.71. 

1. Check out this [PR](https://github.com/silverorange/emrap-corependium/pull/2208) for CoreP app 
2. Set the source for `react-native-image-pan-zoom` to `git+ssh://git@github.com/argeoph/react-native-image-zoom.git#fix-typescript-errors`
3. Run `rm -rf node_modules && yarn `
4. Run `yarn tsc` to confirm that there's no TypeScript errors anymore